### PR TITLE
Add tutorial dungeon generation mode and fixed tutorial spawns

### DIFF
--- a/Assets/Scripts/Map/Dungeon.cs
+++ b/Assets/Scripts/Map/Dungeon.cs
@@ -6,6 +6,12 @@ using Random = UnityEngine.Random;
 
 namespace Map
 {
+    public enum DungeonGenerationMode
+    {
+        RandomExpand,
+        TutorialPreset
+    }
+
     public class Dungeon
     {
         public Dungeon()
@@ -70,7 +76,22 @@ namespace Map
         /// </summary>
         /// <param name="roomCount"> 처리해야하는 방 갯수 </param>
         /// <exception cref="ArgumentException"> 정상적이지 않은 방 갯수가 입력됨 </exception>
-        public void ActivateDungeon(int roomCount)
+        public void ActivateDungeon(int roomCount, DungeonGenerationMode mode)
+        {
+            switch (mode)
+            {
+                case DungeonGenerationMode.RandomExpand:
+                    ActivateRandomDungeon(roomCount);
+                    break;
+                case DungeonGenerationMode.TutorialPreset:
+                    GenerateTutorialLayout();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown dungeon generation mode.");
+            }
+        }
+
+        private void ActivateRandomDungeon(int roomCount)
         {
             if (roomCount > MAX_ROOM_COUNT || roomCount < 1)
                 throw new ArgumentException();
@@ -106,6 +127,31 @@ namespace Map
                         setCount++;
                     }
                 }
+            }
+        }
+
+        private void GenerateTutorialLayout()
+        {
+            Coord startRoomCoord = new Coord(DUNGEON_X / 2, DUNGEON_Y / 2);
+            List<Coord> roomCoords = new List<Coord>
+            {
+                startRoomCoord,
+                new Coord(startRoomCoord.X + 1, startRoomCoord.Y),
+                new Coord(startRoomCoord.X + 2, startRoomCoord.Y)
+            };
+
+            for (int i = 0; i < roomCoords.Count; i++)
+            {
+                Coord roomCoord = roomCoords[i];
+                Room room = _roomPool[i];
+                room.XInDungeon = roomCoord.X;
+                room.YInDungeon = roomCoord.Y;
+                _rooms[roomCoord.X][roomCoord.Y] = room;
+
+                int offsetX = roomCoord.X - startRoomCoord.X;
+                int offsetY = roomCoord.Y - startRoomCoord.Y;
+                room.CenterPos = new Coord(offsetX * Room.X_LENGTH, offsetY * Room.Y_LENGTH);
+                room.SpawnTiles();
             }
         }
 

--- a/Assets/Scripts/Workflows/DungeonSceneWorkflow.cs
+++ b/Assets/Scripts/Workflows/DungeonSceneWorkflow.cs
@@ -19,6 +19,8 @@ namespace Workflows
         private UnitManager _unitManager;
         private EffectPool _effectPool;
 
+        [SerializeField] private bool isTutorial;
+
 
         [Inject]
         public void Construct(Dungeon dungeon, UnitManager unitManager, EffectPool effectPool)
@@ -31,34 +33,45 @@ namespace Workflows
         private void Start()
         {
             _effectPool.Init();
-            _dungeon.ActivateDungeon(7);
+            DungeonGenerationMode generationMode = isTutorial
+                ? DungeonGenerationMode.TutorialPreset
+                : DungeonGenerationMode.RandomExpand;
+            _dungeon.ActivateDungeon(7, generationMode);
 
             Knight knight = _unitManager.SpawnKnight(0, 0);
             knight.PlayerController.NextTurn += NextTurn;
 
-            // 적 15마리 스폰
-            for (int i = 0; i < 15; i++)
+            if (isTutorial)
             {
-                Coord spawnPosition = _dungeon.GetRandomEmptyTileFromRooms(100);
-                
-                if (spawnPosition != Coord.Zero) // 적절한 위치를 찾은 경우
+                _unitManager.SpawnEnemy(typeof(Slime), 2, 0);
+                _unitManager.SpawnEnemy(typeof(Bat), 5, 0);
+            }
+            else
+            {
+                // 적 15마리 스폰
+                for (int i = 0; i < 15; i++)
                 {
-                    int random = Random.Range(0, 2);
-                    switch (random)
-                    {
-                        case 0:
-                            _unitManager.SpawnEnemy(typeof(Bat), spawnPosition.X, spawnPosition.Y);
-                            break;
-                        case 1:
-                            _unitManager.SpawnEnemy(typeof(Slime), spawnPosition.X, spawnPosition.Y);
-                            break;
-                    }
+                    Coord spawnPosition = _dungeon.GetRandomEmptyTileFromRooms(100);
                     
-                }
-                else
-                {
-                    Debug.LogWarning("더 이상 적을 스폰할 수 있는 빈 공간이 없습니다.");
-                    break;
+                    if (spawnPosition != Coord.Zero) // 적절한 위치를 찾은 경우
+                    {
+                        int random = Random.Range(0, 2);
+                        switch (random)
+                        {
+                            case 0:
+                                _unitManager.SpawnEnemy(typeof(Bat), spawnPosition.X, spawnPosition.Y);
+                                break;
+                            case 1:
+                                _unitManager.SpawnEnemy(typeof(Slime), spawnPosition.X, spawnPosition.Y);
+                                break;
+                        }
+                        
+                    }
+                    else
+                    {
+                        Debug.LogWarning("더 이상 적을 스폰할 수 있는 빈 공간이 없습니다.");
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Provide a deterministic dungeon layout for tutorial scenarios instead of the existing random expansion logic.
- Allow the scene workflow to select tutorial mode and use fixed enemy placements for predictable teaching steps.
- Keep existing random dungeon generation intact for normal gameplay via a selectable generation mode.
- Make it easy to extend with additional preset layouts or data-driven coordinate lists later.

### Description
- Added `DungeonGenerationMode` enum and changed `ActivateDungeon` signature to `ActivateDungeon(int, DungeonGenerationMode)` to route generation by mode in `Assets/Scripts/Map/Dungeon.cs`.
- Extracted the original random behavior into `ActivateRandomDungeon(int)` and added `GenerateTutorialLayout()` which places a hardcoded linear preset of rooms at `(7,7)`, `(8,7)`, `(9,7)` and calls `SpawnTiles()` for each room.
- Added a serialized `isTutorial` flag to `Assets/Scripts/Workflows/DungeonSceneWorkflow.cs` and updated `Start()` to call `ActivateDungeon(7, generationMode)` selecting `TutorialPreset` when `isTutorial` is true.
- Switched enemy spawning in tutorial mode to fixed spawns (`SpawnEnemy(typeof(Slime), 2, 0)` and `SpawnEnemy(typeof(Bat), 5, 0)`) while preserving the original random spawn loop for non-tutorial mode.

### Testing
- No automated tests were executed for this change.
- Changes were compiled and committed locally (no CI run reported).
- Manual runtime verification was not recorded as part of this PR.
- Recommend running full project unit/integration tests and a playtest of tutorial and normal modes after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608ba752d88320acec5521eb878a28)