### PR TITLE
Add tutorial dungeon layout ScriptableObject and integrate tutorial generation/spawning

### DIFF
--- a/Assets/Resources/Layouts.meta
+++ b/Assets/Resources/Layouts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 113c9d5c0d2e4330ae0c776126e30a0b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Layouts/TutorialDungeonLayout_Tutorial1.asset
+++ b/Assets/Resources/Layouts/TutorialDungeonLayout_Tutorial1.asset
@@ -19,7 +19,6 @@ MonoBehaviour:
     y: 7
   - x: 9
     y: 7
-  blockedTiles: []
   unitSpawns:
   - x: 2
     y: 0

--- a/Assets/Resources/Layouts/TutorialDungeonLayout_Tutorial1.asset
+++ b/Assets/Resources/Layouts/TutorialDungeonLayout_Tutorial1.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23213f8eba944180a90aeb653de0c4b5, type: 3}
+  m_Name: TutorialDungeonLayout_Tutorial1
+  m_EditorClassIdentifier: 
+  rooms:
+  - x: 7
+    y: 7
+  - x: 8
+    y: 7
+  - x: 9
+    y: 7
+  blockedTiles: []
+  unitSpawns:
+  - x: 2
+    y: 0
+    unitType: 1
+  - x: 5
+    y: 0
+    unitType: 0
+  playerSpawn:
+    X: 0
+    Y: 0

--- a/Assets/Resources/Layouts/TutorialDungeonLayout_Tutorial1.asset.meta
+++ b/Assets/Resources/Layouts/TutorialDungeonLayout_Tutorial1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48b8d2de10074e08a95fe9875b771f03
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Map/Coord.cs
+++ b/Assets/Scripts/Map/Coord.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace Map
 {
+    [Serializable]
     public struct Coord : IEquatable<Coord>
     {
         public Coord(int x, int y)

--- a/Assets/Scripts/Map/Dungeon.cs
+++ b/Assets/Scripts/Map/Dungeon.cs
@@ -169,23 +169,6 @@ namespace Map
                 room.SpawnTiles();
             }
 
-            if (layout.blockedTiles == null)
-            {
-                return;
-            }
-
-            foreach (TileOverride tileOverride in layout.blockedTiles)
-            {
-                Coord tileCoord = tileOverride.ToCoord();
-                if (!TileObjects.ContainsKey(tileCoord))
-                {
-                    continue;
-                }
-
-                Tile tile = GetTile(tileCoord.X, tileCoord.Y);
-                tile.Status = tileOverride.status;
-                SetTile(tileCoord.X, tileCoord.Y, tile);
-            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Map/Dungeon.cs
+++ b/Assets/Scripts/Map/Dungeon.cs
@@ -84,7 +84,6 @@ namespace Map
                     ActivateRandomDungeon(roomCount);
                     break;
                 case DungeonGenerationMode.TutorialPreset:
-                    GenerateTutorialLayout();
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown dungeon generation mode.");
@@ -130,28 +129,62 @@ namespace Map
             }
         }
 
-        private void GenerateTutorialLayout()
+        public void GenerateTutorialLayout(TutorialDungeonLayout layout)
         {
-            Coord startRoomCoord = new Coord(DUNGEON_X / 2, DUNGEON_Y / 2);
-            List<Coord> roomCoords = new List<Coord>
+            if (layout == null)
             {
-                startRoomCoord,
-                new Coord(startRoomCoord.X + 1, startRoomCoord.Y),
-                new Coord(startRoomCoord.X + 2, startRoomCoord.Y)
-            };
+                throw new ArgumentNullException(nameof(layout));
+            }
 
-            for (int i = 0; i < roomCoords.Count; i++)
+            if (layout.rooms == null || layout.rooms.Count == 0)
             {
-                Coord roomCoord = roomCoords[i];
+                Debug.LogWarning("Tutorial layout has no rooms to generate.");
+                return;
+            }
+
+            Coord anchorCoord = layout.rooms[0].ToCoord();
+            for (int i = 0; i < layout.rooms.Count; i++)
+            {
+                Coord roomCoord = layout.rooms[i].ToCoord();
+                if (roomCoord.X < 0 || roomCoord.Y < 0 || roomCoord.X >= DUNGEON_X || roomCoord.Y >= DUNGEON_Y)
+                {
+                    Debug.LogWarning($"Tutorial room coord out of bounds: ({roomCoord.X}, {roomCoord.Y})");
+                    continue;
+                }
+
+                if (i >= _roomPool.Count)
+                {
+                    Debug.LogWarning("Tutorial layout exceeds pooled room count.");
+                    break;
+                }
+
                 Room room = _roomPool[i];
                 room.XInDungeon = roomCoord.X;
                 room.YInDungeon = roomCoord.Y;
                 _rooms[roomCoord.X][roomCoord.Y] = room;
 
-                int offsetX = roomCoord.X - startRoomCoord.X;
-                int offsetY = roomCoord.Y - startRoomCoord.Y;
+                int offsetX = roomCoord.X - anchorCoord.X;
+                int offsetY = roomCoord.Y - anchorCoord.Y;
                 room.CenterPos = new Coord(offsetX * Room.X_LENGTH, offsetY * Room.Y_LENGTH);
                 room.SpawnTiles();
+            }
+
+            if (layout.blockedTiles == null)
+            {
+                return;
+            }
+
+            foreach (TileOverride tileOverride in layout.blockedTiles)
+            {
+                Coord tileCoord = tileOverride.ToCoord();
+                if (!TileObjects.ContainsKey(tileCoord))
+                {
+                    continue;
+                }
+
+                Tile tile = GetTile(tileCoord.X, tileCoord.Y);
+                tile.Status = tileOverride.status;
+                SetTile(tileCoord.X, tileCoord.Y, tile);
             }
         }
 

--- a/Assets/Scripts/Map/TutorialDungeonLayout.cs
+++ b/Assets/Scripts/Map/TutorialDungeonLayout.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Unit;
 using UnityEngine;
 
 namespace Map
@@ -26,7 +27,7 @@ namespace Map
     {
         public int x;
         public int y;
-        public UnitManager.UnitSpawnType unitType;
+        public UnitSpawnType unitType;
 
         public Coord ToCoord() => new Coord(x, y);
     }

--- a/Assets/Scripts/Map/TutorialDungeonLayout.cs
+++ b/Assets/Scripts/Map/TutorialDungeonLayout.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Map
+{
+    [CreateAssetMenu(menuName = "Map/Tutorial Dungeon Layout", fileName = "TutorialDungeonLayout")]
+    public class TutorialDungeonLayout : ScriptableObject
+    {
+        public List<RoomCoord> rooms = new List<RoomCoord>();
+        public List<TileOverride> blockedTiles = new List<TileOverride>();
+        public List<UnitSpawn> unitSpawns = new List<UnitSpawn>();
+        public Coord playerSpawn = Coord.Zero;
+    }
+
+    [Serializable]
+    public struct RoomCoord
+    {
+        public int x;
+        public int y;
+
+        public Coord ToCoord() => new Coord(x, y);
+    }
+
+    [Serializable]
+    public struct TileOverride
+    {
+        public int x;
+        public int y;
+        public StatusFlag status;
+
+        public Coord ToCoord() => new Coord(x, y);
+    }
+
+    public enum UnitSpawnType
+    {
+        Bat,
+        Slime
+    }
+
+    [Serializable]
+    public struct UnitSpawn
+    {
+        public int x;
+        public int y;
+        public UnitSpawnType unitType;
+
+        public Coord ToCoord() => new Coord(x, y);
+    }
+}

--- a/Assets/Scripts/Map/TutorialDungeonLayout.cs
+++ b/Assets/Scripts/Map/TutorialDungeonLayout.cs
@@ -8,7 +8,6 @@ namespace Map
     public class TutorialDungeonLayout : ScriptableObject
     {
         public List<RoomCoord> rooms = new List<RoomCoord>();
-        public List<TileOverride> blockedTiles = new List<TileOverride>();
         public List<UnitSpawn> unitSpawns = new List<UnitSpawn>();
         public Coord playerSpawn = Coord.Zero;
     }
@@ -23,27 +22,11 @@ namespace Map
     }
 
     [Serializable]
-    public struct TileOverride
-    {
-        public int x;
-        public int y;
-        public StatusFlag status;
-
-        public Coord ToCoord() => new Coord(x, y);
-    }
-
-    public enum UnitSpawnType
-    {
-        Bat,
-        Slime
-    }
-
-    [Serializable]
     public struct UnitSpawn
     {
         public int x;
         public int y;
-        public UnitSpawnType unitType;
+        public UnitManager.UnitSpawnType unitType;
 
         public Coord ToCoord() => new Coord(x, y);
     }

--- a/Assets/Scripts/Map/TutorialDungeonLayout.cs.meta
+++ b/Assets/Scripts/Map/TutorialDungeonLayout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23213f8eba944180a90aeb653de0c4b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Unit/UnitManager.cs
+++ b/Assets/Scripts/Unit/UnitManager.cs
@@ -9,14 +9,14 @@ using VContainer;
 
 namespace Unit
 {
+    public enum UnitSpawnType
+    {
+        Bat,
+        Slime
+    }
+    
     public class UnitManager
     {
-        public enum UnitSpawnType
-        {
-            Bat,
-            Slime
-        }
-
         public Knight Knight { get; private set; }
 
 
@@ -46,48 +46,65 @@ namespace Unit
         /// <summary>
         /// (X, Y) 위치에 type Enemy를 스폰하는 함수
         /// </summary>
-        public Enemy.Enemy SpawnEnemy(Type type, int x, int y)
+        // public Enemy.Enemy SpawnEnemy(Type type, int x, int y)
+        // {
+        //     Enemy.Enemy enemy;
+        //     
+        //     if (type == typeof(Bat))
+        //     {
+        //         enemy = new Bat(_dungeon, this, _effectPool)
+        //         {
+        //             Position = new Coord(x, y),
+        //         };
+        //     }
+        //     else if (type == typeof(Slime))
+        //     {
+        //         enemy = new Slime(_dungeon, this, _effectPool)
+        //         {
+        //             Position = new Coord(x, y),
+        //         };
+        //     }
+        //     else
+        //     {
+        //         throw new Exception($"[{nameof(SpawnEnemy)}] Invalid type");
+        //     }
+        //
+        //     enemy.Transform.position = new Vector3(x, y, -1);
+        //     _dungeon.Tiles[x + Dungeon.DUNGEON_X * Room.X_LENGTH / 2][y + Dungeon.DUNGEON_Y * Room.Y_LENGTH / 2].Unit = enemy;
+        //     
+        //     _enemies.Add(enemy);
+        //     
+        //     return enemy;
+        // }
+
+        public Enemy.Enemy SpawnEnemy(UnitSpawnType unitType, int x, int y)
         {
             Enemy.Enemy enemy;
             
-            if (type == typeof(Bat))
+            switch (unitType)
             {
-                enemy = new Bat(_dungeon, this, _effectPool)
-                {
-                    Position = new Coord(x, y),
-                };
+                case UnitSpawnType.Bat:
+                    enemy = new Bat(_dungeon, this, _effectPool)
+                    {
+                        Position = new Coord(x, y),
+                    };
+                    break;
+                case UnitSpawnType.Slime:
+                    enemy = new Slime(_dungeon, this, _effectPool)
+                    {
+                        Position = new Coord(x, y),
+                    };
+                    break;
+                default:
+                    throw new Exception($"[{nameof(SpawnEnemy)}] Invalid unit spawn type");
             }
-            else if (type == typeof(Slime))
-            {
-                enemy = new Slime(_dungeon, this, _effectPool)
-                {
-                    Position = new Coord(x, y),
-                };
-            }
-            else
-            {
-                throw new Exception($"[{nameof(SpawnEnemy)}] Invalid type");
-            }
-
+            
             enemy.Transform.position = new Vector3(x, y, -1);
             _dungeon.Tiles[x + Dungeon.DUNGEON_X * Room.X_LENGTH / 2][y + Dungeon.DUNGEON_Y * Room.Y_LENGTH / 2].Unit = enemy;
             
             _enemies.Add(enemy);
             
             return enemy;
-        }
-
-        public Enemy.Enemy SpawnEnemy(UnitSpawnType unitType, int x, int y)
-        {
-            switch (unitType)
-            {
-                case UnitSpawnType.Bat:
-                    return SpawnEnemy(typeof(Bat), x, y);
-                case UnitSpawnType.Slime:
-                    return SpawnEnemy(typeof(Slime), x, y);
-                default:
-                    throw new Exception($"[{nameof(SpawnEnemy)}] Invalid unit spawn type");
-            }
         }
 
         public void RemoveEnemy(Enemy.Enemy enemy)

--- a/Assets/Scripts/Unit/UnitManager.cs
+++ b/Assets/Scripts/Unit/UnitManager.cs
@@ -11,6 +11,12 @@ namespace Unit
 {
     public class UnitManager
     {
+        public enum UnitSpawnType
+        {
+            Bat,
+            Slime
+        }
+
         public Knight Knight { get; private set; }
 
 
@@ -69,6 +75,19 @@ namespace Unit
             _enemies.Add(enemy);
             
             return enemy;
+        }
+
+        public Enemy.Enemy SpawnEnemy(UnitSpawnType unitType, int x, int y)
+        {
+            switch (unitType)
+            {
+                case UnitSpawnType.Bat:
+                    return SpawnEnemy(typeof(Bat), x, y);
+                case UnitSpawnType.Slime:
+                    return SpawnEnemy(typeof(Slime), x, y);
+                default:
+                    throw new Exception($"[{nameof(SpawnEnemy)}] Invalid unit spawn type");
+            }
         }
 
         public void RemoveEnemy(Enemy.Enemy enemy)

--- a/Assets/Scripts/Workflows/DungeonSceneWorkflow.cs
+++ b/Assets/Scripts/Workflows/DungeonSceneWorkflow.cs
@@ -82,10 +82,10 @@ namespace Workflows
                         switch (random)
                         {
                             case 0:
-                                _unitManager.SpawnEnemy(typeof(Bat), spawnPosition.X, spawnPosition.Y);
+                                _unitManager.SpawnEnemy(UnitSpawnType.Bat, spawnPosition.X, spawnPosition.Y);
                                 break;
                             case 1:
-                                _unitManager.SpawnEnemy(typeof(Slime), spawnPosition.X, spawnPosition.Y);
+                                _unitManager.SpawnEnemy(UnitSpawnType.Slime, spawnPosition.X, spawnPosition.Y);
                                 break;
                         }
                         

--- a/Assets/Scripts/Workflows/DungeonSceneWorkflow.cs
+++ b/Assets/Scripts/Workflows/DungeonSceneWorkflow.cs
@@ -65,9 +65,8 @@ namespace Workflows
             {
                 foreach (UnitSpawn spawn in activeLayout.unitSpawns)
                 {
-                    Type enemyType = ResolveEnemyType(spawn.unitType);
                     Coord spawnCoord = spawn.ToCoord();
-                    _unitManager.SpawnEnemy(enemyType, spawnCoord.X, spawnCoord.Y);
+                    _unitManager.SpawnEnemy(spawn.unitType, spawnCoord.X, spawnCoord.Y);
                 }
             }
             else
@@ -105,17 +104,5 @@ namespace Workflows
             _unitManager.ActOnAllEnemies();
         }
 
-        private static Type ResolveEnemyType(UnitSpawnType unitSpawnType)
-        {
-            switch (unitSpawnType)
-            {
-                case UnitSpawnType.Bat:
-                    return typeof(Bat);
-                case UnitSpawnType.Slime:
-                    return typeof(Slime);
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(unitSpawnType), unitSpawnType, "Unknown enemy type");
-            }
-        }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide deterministic tutorial dungeon layouts that can be authored as assets for designer-driven scenarios.
- Allow explicit placement of rooms, blocked/overridden tiles, enemy spawns and the player spawn so tutorials are reproducible.
- Enable runtime loading of tutorial layouts so multiple tutorial steps can be swapped without code changes.

### Description
- Add `TutorialDungeonLayout` ScriptableObject and serializable types `RoomCoord`, `TileOverride`, `UnitSpawn`, and `UnitSpawnType` in `Assets/Scripts/Map/TutorialDungeonLayout.cs`.
- Make `Coord` serializable by adding the `[Serializable]` attribute so layout data can be serialized into assets via the inspector.
- Add `public void GenerateTutorialLayout(TutorialDungeonLayout layout)` to `Dungeon` to place rooms from `layout.rooms`, call `SpawnTiles()`, and apply `layout.blockedTiles` to update tile `StatusFlag`.
- Update `DungeonSceneWorkflow` to load a layout (inspector-injected or `Resources.Load`), call `_dungeon.GenerateTutorialLayout(activeLayout)`, spawn the player at `playerSpawn`, and spawn enemies according to `unitSpawns`.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961b707c8ec8320877df1e504aa160c)