### PR TITLE
Add TileRules helpers, replace StatusFlag checks, and integrate preset-based dungeon generator

### DIFF
--- a/Assets/Scripts/Controller/PlayerController.cs
+++ b/Assets/Scripts/Controller/PlayerController.cs
@@ -59,7 +59,7 @@ namespace Controller
             
             Tile tile = _knight.Dungeon.GetTile(nextXPos, nextYPos);
             
-            if ((tile.Status & StatusFlag.Empty) > 0)
+            if (!TileRules.IsBlockedForPlayer(tile))
             {
                 Tile curTile = _knight.Dungeon.GetTile(_knight.Position.X, _knight.Position.Y);
                 curTile.Player = null;
@@ -73,15 +73,12 @@ namespace Controller
                 curTile.Player = _knight;
                 _knight.Dungeon.SetTile(_knight.Position.X, _knight.Position.Y, curTile);
             }
-            else if ((tile.Status & StatusFlag.Unit) > 0)
+            else if (TileRules.TryGetEnemy(tile, out Enemy enemy))
             {
                 //해당 유닛이 아이템이면
                 
                 //해당 유닛이 Enemy이면
-                if (tile.Unit is Enemy enemy)
-                {
-                    enemy.TakeDamage(1);
-                }
+                enemy.TakeDamage(1);
             }
             
             NextTurn?.Invoke();

--- a/Assets/Scripts/Map/Dungeon.cs
+++ b/Assets/Scripts/Map/Dungeon.cs
@@ -208,6 +208,41 @@ namespace Map
             TileObjects.Add(tile.Coord, tileGo);
         }
 
+        public void ClearTiles()
+        {
+            foreach (var tileObject in TileObjects.Values)
+            {
+                if (tileObject != null)
+                {
+                    GameObject.Destroy(tileObject);
+                }
+            }
+
+            TileObjects.Clear();
+            for (int i = 0; i < DUNGEON_X * Room.X_LENGTH; i++)
+            {
+                Tiles[i] = new Tile[DUNGEON_Y * Room.Y_LENGTH];
+            }
+        }
+
+        public bool TryGetTile(int x, int y, out Tile tile)
+        {
+            Coord coord = new Coord(x, y);
+            if (!HasTile(coord))
+            {
+                tile = default;
+                return false;
+            }
+
+            tile = GetTile(x, y);
+            return true;
+        }
+
+        public bool HasTile(Coord coord)
+        {
+            return TileObjects.ContainsKey(coord);
+        }
+
         public Tile GetTile(int x, int y)
         {
             x += DUNGEON_X * Room.X_LENGTH / 2;
@@ -224,6 +259,18 @@ namespace Map
         public void SetTile(int x, int y, Tile tile)
         {
             Tiles[x + DUNGEON_X * Room.X_LENGTH / 2][y + DUNGEON_Y * Room.Y_LENGTH / 2] = tile;
+        }
+
+        public void SetOrRegisterTile(Tile tile)
+        {
+            if (HasTile(tile.Coord))
+            {
+                SetTile(tile.Coord.X, tile.Coord.Y, tile);
+            }
+            else
+            {
+                RegisterTile(tile);
+            }
         }
         
         /// <summary>
@@ -249,7 +296,7 @@ namespace Map
 
                 // 해당 타일이 비어 있는지 확인
                 Tile tile = GetTile(tileX, tileY);
-                if (tile.Status.HasFlag(StatusFlag.Empty))
+                if (TileRules.IsSpawnable(tile))
                 {
                     return new Coord(tileX, tileY);
                 }

--- a/Assets/Scripts/Map/Generation/DungeonPresetGenerator.cs
+++ b/Assets/Scripts/Map/Generation/DungeonPresetGenerator.cs
@@ -1,0 +1,612 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Map.Generation
+{
+    [Serializable]
+    public class DungeonPresetGenerationConfig
+    {
+        public List<RoomPreset> NormalPresets = new();
+        public List<RoomPreset> ExitPresets = new();
+        public int PresetRoomCount = 6;
+        public int MinRoomDistance = 4;
+        public int MaxRoomDistance = 6;
+        public int MaxPlacementAttempts = 50;
+        public int ExtraExitConnections = 1;
+    }
+
+    public struct DungeonPresetUnitSpawn
+    {
+        public Coord Position;
+        public RoomPresetUnitType UnitType;
+    }
+
+    public class DungeonGenerationResult
+    {
+        public Coord StartPosition { get; init; }
+        public RoomInstance StartRoom { get; init; }
+        public RoomInstance ExitRoom { get; init; }
+        public List<RoomInstance> Rooms { get; init; } = new();
+        public List<DungeonPresetUnitSpawn> UnitSpawns { get; init; } = new();
+    }
+
+    public class RoomInstance
+    {
+        public RoomPreset Preset { get; init; }
+        public Coord Center { get; init; }
+        public RectInt Bounds { get; init; }
+        public List<Coord> DoorWorldPositions { get; init; } = new();
+    }
+
+    public class DungeonPresetGenerator
+    {
+        private readonly Dungeon _dungeon;
+
+        public DungeonPresetGenerator(Dungeon dungeon)
+        {
+            _dungeon = dungeon;
+        }
+
+        public DungeonGenerationResult Generate(DungeonPresetGenerationConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (config.NormalPresets.Count == 0) throw new ArgumentException("Normal presets are required.");
+            if (config.ExitPresets.Count == 0) throw new ArgumentException("Exit presets are required.");
+
+            _dungeon.ClearTiles();
+
+            RoomInstance startRoom = CreateStartRoom();
+            List<RoomInstance> rooms = new List<RoomInstance> { startRoom };
+            List<RoomPreset> selectedNormalPresets = PickRandomPresets(config.NormalPresets, config.PresetRoomCount);
+
+            foreach (RoomPreset preset in selectedNormalPresets)
+            {
+                RoomInstance room = PlaceRoom(config, rooms, preset);
+                if (room != null)
+                {
+                    rooms.Add(room);
+                }
+            }
+
+            RoomInstance exitRoom = PlaceRoom(config, rooms, PickRandomPresets(config.ExitPresets, 1).First());
+            if (exitRoom != null)
+            {
+                rooms.Add(exitRoom);
+            }
+
+            BuildRooms(rooms);
+            List<DungeonPresetUnitSpawn> unitSpawns = ApplyUnits(rooms);
+
+            ConnectRoomsSequentially(rooms);
+            if (exitRoom != null)
+            {
+                ConnectExitRoom(startRoom, exitRoom, rooms, config.ExtraExitConnections);
+            }
+
+            return new DungeonGenerationResult
+            {
+                StartPosition = startRoom.Center,
+                StartRoom = startRoom,
+                ExitRoom = exitRoom,
+                Rooms = rooms,
+                UnitSpawns = unitSpawns,
+            };
+        }
+
+        private RoomInstance CreateStartRoom()
+        {
+            Vector2Int size = GetRoomTileSize(RoomSizeType.OneByOne);
+            Coord center = new Coord(0, 0);
+            RectInt bounds = BuildBounds(center, size);
+
+            List<Coord> doorPositions = new List<Coord>
+            {
+                new Coord(center.X, bounds.yMax - 1),
+                new Coord(center.X, bounds.yMin),
+                new Coord(bounds.xMin, center.Y),
+                new Coord(bounds.xMax - 1, center.Y),
+            };
+
+            return new RoomInstance
+            {
+                Preset = null,
+                Center = center,
+                Bounds = bounds,
+                DoorWorldPositions = doorPositions,
+            };
+        }
+
+        private List<RoomPreset> PickRandomPresets(List<RoomPreset> presets, int count)
+        {
+            if (count <= 0) return new List<RoomPreset>();
+            List<RoomPreset> pool = new List<RoomPreset>(presets);
+            List<RoomPreset> selected = new List<RoomPreset>();
+            int total = Mathf.Min(count, pool.Count);
+
+            for (int i = 0; i < total; i++)
+            {
+                int index = UnityEngine.Random.Range(0, pool.Count);
+                selected.Add(pool[index]);
+                pool.RemoveAt(index);
+            }
+
+            return selected;
+        }
+
+        private RoomInstance PlaceRoom(DungeonPresetGenerationConfig config, List<RoomInstance> rooms, RoomPreset preset)
+        {
+            for (int attempt = 0; attempt < config.MaxPlacementAttempts; attempt++)
+            {
+                RoomInstance anchor = rooms[UnityEngine.Random.Range(0, rooms.Count)];
+                Vector2Int offset = PickRandomOffset(config.MinRoomDistance, config.MaxRoomDistance);
+                Coord center = new Coord(anchor.Center.X + offset.x * Room.X_LENGTH, anchor.Center.Y + offset.y * Room.Y_LENGTH);
+                RectInt bounds = BuildBounds(center, GetRoomTileSize(preset.Size));
+
+                if (!IsWithinDungeonBounds(bounds)) continue;
+                if (rooms.Any(room => room.Bounds.Overlaps(bounds))) continue;
+
+                return CreateRoomInstance(preset, center, bounds);
+            }
+
+            Debug.LogWarning($"Room preset placement failed: {preset.name}");
+            return null;
+        }
+
+        private RoomInstance CreateRoomInstance(RoomPreset preset, Coord center, RectInt bounds)
+        {
+            List<Coord> doorWorldPositions = new List<Coord>();
+            if (preset != null)
+            {
+                foreach (RoomPresetDoor door in preset.Doors)
+                {
+                    doorWorldPositions.Add(new Coord(center.X + door.LocalPosition.x, center.Y + door.LocalPosition.y));
+                }
+            }
+
+            return new RoomInstance
+            {
+                Preset = preset,
+                Center = center,
+                Bounds = bounds,
+                DoorWorldPositions = doorWorldPositions,
+            };
+        }
+
+        private Vector2Int PickRandomOffset(int minDistance, int maxDistance)
+        {
+            int distance = UnityEngine.Random.Range(minDistance, maxDistance + 1);
+            int dx = UnityEngine.Random.Range(-distance, distance + 1);
+            int dy = distance - Mathf.Abs(dx);
+            dy *= UnityEngine.Random.value < 0.5f ? -1 : 1;
+
+            if (dx == 0 && dy == 0)
+            {
+                dx = distance;
+            }
+
+            return new Vector2Int(dx, dy);
+        }
+
+        private void BuildRooms(List<RoomInstance> rooms)
+        {
+            foreach (RoomInstance room in rooms)
+            {
+                HashSet<Coord> doors = new HashSet<Coord>(room.DoorWorldPositions);
+                for (int x = room.Bounds.xMin; x < room.Bounds.xMax; x++)
+                {
+                    for (int y = room.Bounds.yMin; y < room.Bounds.yMax; y++)
+                    {
+                        Coord coord = new Coord(x, y);
+                        bool isEdge = x == room.Bounds.xMin || x == room.Bounds.xMax - 1 || y == room.Bounds.yMin || y == room.Bounds.yMax - 1;
+                        bool isDoor = doors.Contains(coord);
+
+                        Tile tile = new Tile
+                        {
+                            Coord = coord,
+                            Status = isEdge && !isDoor ? StatusFlag.Blocked : StatusFlag.Empty,
+                        };
+
+                        _dungeon.SetOrRegisterTile(tile);
+                    }
+                }
+            }
+        }
+
+        private List<DungeonPresetUnitSpawn> ApplyUnits(List<RoomInstance> rooms)
+        {
+            List<DungeonPresetUnitSpawn> spawns = new List<DungeonPresetUnitSpawn>();
+
+            foreach (RoomInstance room in rooms)
+            {
+                if (room.Preset == null) continue;
+
+                foreach (RoomPresetUnitPlacement placement in room.Preset.Units)
+                {
+                    Coord coord = new Coord(room.Center.X + placement.LocalPosition.x, room.Center.Y + placement.LocalPosition.y);
+                    if (!_dungeon.HasTile(coord)) continue;
+
+                    switch (placement.UnitType)
+                    {
+                        case RoomPresetUnitType.Bat:
+                        case RoomPresetUnitType.Slime:
+                            spawns.Add(new DungeonPresetUnitSpawn
+                            {
+                                Position = coord,
+                                UnitType = placement.UnitType,
+                            });
+                            break;
+                        case RoomPresetUnitType.Blocker:
+                        case RoomPresetUnitType.Item:
+                            if (_dungeon.TryGetTile(coord.X, coord.Y, out Tile tile))
+                            {
+                                tile.Status = StatusFlag.Blocked;
+                                _dungeon.SetOrRegisterTile(tile);
+                            }
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+
+            return spawns;
+        }
+
+        private void ConnectRoomsSequentially(List<RoomInstance> rooms)
+        {
+            for (int i = 1; i < rooms.Count; i++)
+            {
+                RoomInstance from = rooms[i - 1];
+                RoomInstance to = rooms[i];
+                TryConnectRooms(from, to, rooms);
+            }
+        }
+
+        private void ConnectExitRoom(RoomInstance startRoom, RoomInstance exitRoom, List<RoomInstance> rooms, int extraConnections)
+        {
+            RoomInstance farthest = rooms
+                .Where(room => room != exitRoom)
+                .OrderByDescending(room => ManhattanDistance(startRoom.Center, room.Center))
+                .FirstOrDefault();
+
+            if (farthest != null)
+            {
+                TryConnectRooms(farthest, exitRoom, rooms);
+            }
+
+            List<RoomInstance> nearestRooms = rooms
+                .Where(room => room != exitRoom)
+                .OrderBy(room => ManhattanDistance(exitRoom.Center, room.Center))
+                .Take(Mathf.Max(0, extraConnections))
+                .ToList();
+
+            foreach (RoomInstance room in nearestRooms)
+            {
+                TryConnectRooms(room, exitRoom, rooms);
+            }
+        }
+
+        private void TryConnectRooms(RoomInstance from, RoomInstance to, List<RoomInstance> rooms)
+        {
+            List<Coord> fromDoors = EnsureDoors(from);
+            List<Coord> toDoors = EnsureDoors(to);
+
+            (Coord start, Coord end) = FindClosestDoorPair(fromDoors, toDoors);
+            if (TryCreateCorridor(start, end, rooms))
+            {
+                return;
+            }
+
+            foreach (Coord fromDoor in fromDoors)
+            {
+                foreach (Coord toDoor in toDoors)
+                {
+                    if (TryCreateCorridor(fromDoor, toDoor, rooms))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            Debug.LogWarning($"Failed to connect rooms at {from.Center.X},{from.Center.Y} and {to.Center.X},{to.Center.Y}");
+        }
+
+        private List<Coord> EnsureDoors(RoomInstance room)
+        {
+            if (room.DoorWorldPositions.Count > 0)
+            {
+                return room.DoorWorldPositions;
+            }
+
+            List<Coord> defaultDoors = new List<Coord>
+            {
+                new Coord(room.Center.X, room.Bounds.yMax - 1),
+                new Coord(room.Center.X, room.Bounds.yMin),
+                new Coord(room.Bounds.xMin, room.Center.Y),
+                new Coord(room.Bounds.xMax - 1, room.Center.Y),
+            };
+
+            return defaultDoors;
+        }
+
+        private (Coord start, Coord end) FindClosestDoorPair(List<Coord> fromDoors, List<Coord> toDoors)
+        {
+            Coord bestStart = fromDoors[0];
+            Coord bestEnd = toDoors[0];
+            int bestDistance = int.MaxValue;
+
+            foreach (Coord fromDoor in fromDoors)
+            {
+                foreach (Coord toDoor in toDoors)
+                {
+                    int distance = ManhattanDistance(fromDoor, toDoor);
+                    if (distance < bestDistance)
+                    {
+                        bestDistance = distance;
+                        bestStart = fromDoor;
+                        bestEnd = toDoor;
+                    }
+                }
+            }
+
+            return (bestStart, bestEnd);
+        }
+
+        private bool TryCreateCorridor(Coord startDoor, Coord endDoor, List<RoomInstance> rooms)
+        {
+            if (!TryGetOutsideDoor(startDoor, rooms, out Coord startOutside) ||
+                !TryGetOutsideDoor(endDoor, rooms, out Coord endOutside))
+            {
+                return false;
+            }
+
+            if (!IsWithinDungeonBounds(startOutside) || !IsWithinDungeonBounds(endOutside))
+            {
+                return false;
+            }
+
+            HashSet<Coord> allowed = new HashSet<Coord> { startDoor, endDoor };
+            if (TryBuildSingleBendPath(startOutside, endOutside, rooms, allowed, out List<Coord> path))
+            {
+                CarveCorridor(startDoor, startOutside, path, endOutside, endDoor);
+                return true;
+            }
+
+            if (TryBuildTwoBendPath(startOutside, endOutside, rooms, allowed, out path))
+            {
+                CarveCorridor(startDoor, startOutside, path, endOutside, endDoor);
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryGetOutsideDoor(Coord door, List<RoomInstance> rooms, out Coord outside)
+        {
+            foreach (RoomInstance room in rooms)
+            {
+                if (!room.Bounds.Contains(new Vector2Int(door.X, door.Y))) continue;
+
+                if (door.Y == room.Bounds.yMax - 1)
+                {
+                    outside = new Coord(door.X, door.Y + 1);
+                    return true;
+                }
+
+                if (door.Y == room.Bounds.yMin)
+                {
+                    outside = new Coord(door.X, door.Y - 1);
+                    return true;
+                }
+
+                if (door.X == room.Bounds.xMin)
+                {
+                    outside = new Coord(door.X - 1, door.Y);
+                    return true;
+                }
+
+                if (door.X == room.Bounds.xMax - 1)
+                {
+                    outside = new Coord(door.X + 1, door.Y);
+                    return true;
+                }
+
+                Debug.LogWarning($"Door at {door.X},{door.Y} is not on room edge.");
+                break;
+            }
+
+            outside = default;
+            return false;
+        }
+
+        private bool TryBuildSingleBendPath(Coord start, Coord end, List<RoomInstance> rooms, HashSet<Coord> allowed, out List<Coord> path)
+        {
+            Coord cornerA = new Coord(end.X, start.Y);
+            if (IsPathClear(start, cornerA, rooms, allowed) && IsPathClear(cornerA, end, rooms, allowed))
+            {
+                path = BuildPath(start, cornerA, end);
+                return true;
+            }
+
+            Coord cornerB = new Coord(start.X, end.Y);
+            if (IsPathClear(start, cornerB, rooms, allowed) && IsPathClear(cornerB, end, rooms, allowed))
+            {
+                path = BuildPath(start, cornerB, end);
+                return true;
+            }
+
+            path = null;
+            return false;
+        }
+
+        private bool TryBuildTwoBendPath(Coord start, Coord end, List<RoomInstance> rooms, HashSet<Coord> allowed, out List<Coord> path)
+        {
+            int detourRange = 6;
+            List<int> offsets = Enumerable.Range(-detourRange, detourRange * 2 + 1)
+                .Where(value => value != 0)
+                .OrderBy(_ => UnityEngine.Random.value)
+                .ToList();
+
+            foreach (int offset in offsets)
+            {
+                Coord mid1 = new Coord(start.X + offset, start.Y);
+                Coord mid2 = new Coord(start.X + offset, end.Y);
+
+                if (IsPathClear(start, mid1, rooms, allowed) &&
+                    IsPathClear(mid1, mid2, rooms, allowed) &&
+                    IsPathClear(mid2, end, rooms, allowed))
+                {
+                    path = BuildPath(start, mid1, mid2, end);
+                    return true;
+                }
+            }
+
+            foreach (int offset in offsets)
+            {
+                Coord mid1 = new Coord(start.X, start.Y + offset);
+                Coord mid2 = new Coord(end.X, start.Y + offset);
+
+                if (IsPathClear(start, mid1, rooms, allowed) &&
+                    IsPathClear(mid1, mid2, rooms, allowed) &&
+                    IsPathClear(mid2, end, rooms, allowed))
+                {
+                    path = BuildPath(start, mid1, mid2, end);
+                    return true;
+                }
+            }
+
+            path = null;
+            return false;
+        }
+
+        private List<Coord> BuildPath(params Coord[] points)
+        {
+            List<Coord> path = new List<Coord>();
+
+            for (int i = 0; i < points.Length - 1; i++)
+            {
+                foreach (Coord point in EnumerateLine(points[i], points[i + 1]))
+                {
+                    if (path.Count == 0 || path[^1] != point)
+                    {
+                        path.Add(point);
+                    }
+                }
+            }
+
+            return path;
+        }
+
+        private IEnumerable<Coord> EnumerateLine(Coord start, Coord end)
+        {
+            if (start.X == end.X)
+            {
+                int step = start.Y <= end.Y ? 1 : -1;
+                for (int y = start.Y; y != end.Y + step; y += step)
+                {
+                    yield return new Coord(start.X, y);
+                }
+                yield break;
+            }
+
+            if (start.Y == end.Y)
+            {
+                int step = start.X <= end.X ? 1 : -1;
+                for (int x = start.X; x != end.X + step; x += step)
+                {
+                    yield return new Coord(x, start.Y);
+                }
+                yield break;
+            }
+
+            throw new ArgumentException("Only axis-aligned lines are supported.");
+        }
+
+        private bool IsPathClear(Coord start, Coord end, List<RoomInstance> rooms, HashSet<Coord> allowed)
+        {
+            foreach (Coord point in EnumerateLine(start, end))
+            {
+                if (allowed.Contains(point)) continue;
+
+                foreach (RoomInstance room in rooms)
+                {
+                    if (room.Bounds.Contains(new Vector2Int(point.X, point.Y)))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private void CarveCorridor(Coord startDoor, Coord startOutside, List<Coord> path, Coord endOutside, Coord endDoor)
+        {
+            List<Coord> corridor = new List<Coord> { startDoor, startOutside };
+            corridor.AddRange(path);
+            corridor.Add(endOutside);
+            corridor.Add(endDoor);
+
+            foreach (Coord coord in corridor.Distinct())
+            {
+                if (!IsWithinDungeonBounds(coord)) continue;
+
+                Tile tile = new Tile
+                {
+                    Coord = coord,
+                    Status = StatusFlag.Empty,
+                };
+                _dungeon.SetOrRegisterTile(tile);
+            }
+        }
+
+        private RectInt BuildBounds(Coord center, Vector2Int size)
+        {
+            int minX = center.X - size.x / 2;
+            int minY = center.Y - size.y / 2;
+            return new RectInt(minX, minY, size.x, size.y);
+        }
+
+        private Vector2Int GetRoomTileSize(RoomSizeType sizeType)
+        {
+            return sizeType switch
+            {
+                RoomSizeType.OneByOne => new Vector2Int(Room.X_LENGTH, Room.Y_LENGTH),
+                RoomSizeType.TwoByOne => new Vector2Int(Room.X_LENGTH * 2, Room.Y_LENGTH),
+                RoomSizeType.OneByTwo => new Vector2Int(Room.X_LENGTH, Room.Y_LENGTH * 2),
+                RoomSizeType.TwoByTwo => new Vector2Int(Room.X_LENGTH * 2, Room.Y_LENGTH * 2),
+                _ => throw new ArgumentOutOfRangeException(nameof(sizeType), sizeType, null),
+            };
+        }
+
+        private int ManhattanDistance(Coord a, Coord b)
+        {
+            return Mathf.Abs(a.X - b.X) + Mathf.Abs(a.Y - b.Y);
+        }
+
+        private bool IsWithinDungeonBounds(RectInt bounds)
+        {
+            int minX = -(Dungeon.DUNGEON_X * Room.X_LENGTH / 2);
+            int maxX = Dungeon.DUNGEON_X * Room.X_LENGTH / 2;
+            int minY = -(Dungeon.DUNGEON_Y * Room.Y_LENGTH / 2);
+            int maxY = Dungeon.DUNGEON_Y * Room.Y_LENGTH / 2;
+
+            return bounds.xMin >= minX &&
+                   bounds.yMin >= minY &&
+                   bounds.xMax <= maxX &&
+                   bounds.yMax <= maxY;
+        }
+
+        private bool IsWithinDungeonBounds(Coord coord)
+        {
+            int minX = -(Dungeon.DUNGEON_X * Room.X_LENGTH / 2);
+            int maxX = Dungeon.DUNGEON_X * Room.X_LENGTH / 2;
+            int minY = -(Dungeon.DUNGEON_Y * Room.Y_LENGTH / 2);
+            int maxY = Dungeon.DUNGEON_Y * Room.Y_LENGTH / 2;
+
+            return coord.X >= minX && coord.X < maxX && coord.Y >= minY && coord.Y < maxY;
+        }
+    }
+}

--- a/Assets/Scripts/Map/Generation/RoomPreset.cs
+++ b/Assets/Scripts/Map/Generation/RoomPreset.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Map.Generation
+{
+    public enum RoomPresetRole
+    {
+        Normal,
+        Exit
+    }
+
+    public enum RoomSizeType
+    {
+        OneByOne,
+        TwoByOne,
+        OneByTwo,
+        TwoByTwo
+    }
+
+    public enum RoomPresetUnitType
+    {
+        Bat,
+        Slime,
+        Blocker,
+        Item
+    }
+
+    [Serializable]
+    public struct RoomPresetDoor
+    {
+        public Vector2Int LocalPosition;
+    }
+
+    [Serializable]
+    public struct RoomPresetUnitPlacement
+    {
+        public Vector2Int LocalPosition;
+        public RoomPresetUnitType UnitType;
+    }
+
+    [CreateAssetMenu(menuName = "Dungeon/Room Preset", fileName = "RoomPreset")]
+    public class RoomPreset : ScriptableObject
+    {
+        public RoomSizeType Size = RoomSizeType.OneByOne;
+        public RoomPresetRole Role = RoomPresetRole.Normal;
+        public List<RoomPresetDoor> Doors = new();
+        public List<RoomPresetUnitPlacement> Units = new();
+    }
+}

--- a/Assets/Scripts/Map/TileRules.cs
+++ b/Assets/Scripts/Map/TileRules.cs
@@ -1,0 +1,43 @@
+using Unit.Enemy;
+
+namespace Map
+{
+    public static class TileRules
+    {
+        public static bool HasPlayer(Tile tile) => tile.Player != null;
+        public static bool HasUnit(Tile tile) => tile.Unit != null;
+        public static bool IsBlocked(Tile tile) => tile.Status.HasFlag(StatusFlag.Blocked);
+
+        public static bool IsBlockedForEnemy(Tile tile)
+        {
+            return IsBlocked(tile) || HasUnit(tile);
+        }
+
+        public static bool CanEnemyMoveTo(Tile tile)
+        {
+            return !IsBlockedForEnemy(tile) && !HasPlayer(tile);
+        }
+
+        public static bool IsBlockedForPlayer(Tile tile)
+        {
+            return IsBlocked(tile) || tile.Unit is Enemy;
+        }
+
+        public static bool IsSpawnable(Tile tile)
+        {
+            return !IsBlocked(tile) && !HasUnit(tile) && !HasPlayer(tile);
+        }
+
+        public static bool TryGetEnemy(Tile tile, out Enemy enemy)
+        {
+            if (tile.Unit is Enemy found)
+            {
+                enemy = found;
+                return true;
+            }
+
+            enemy = null;
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Unit/Enemy/BT/MoveRandomlyAction.cs
+++ b/Assets/Scripts/Unit/Enemy/BT/MoveRandomlyAction.cs
@@ -40,7 +40,7 @@ namespace Unit.Enemy.BT
                     );
 
                     // 이동 가능한 타일만 추가
-                    if (candidateTile.Status == StatusFlag.Empty)
+                    if (TileRules.CanEnemyMoveTo(candidateTile))
                     {
                         nextTileList.Add(candidateTile);
                     }

--- a/Assets/Scripts/Unit/Enemy/BT/MoveToTargetAction.cs
+++ b/Assets/Scripts/Unit/Enemy/BT/MoveToTargetAction.cs
@@ -25,7 +25,8 @@ namespace Unit.Enemy.BT
                 return Result.Success;
             }
 
-            if (_blackBoard.TargetPlayer == null || _blackBoard.TargetPlayer.CurTile.Status != StatusFlag.Empty)
+            if (_blackBoard.TargetPlayer == null ||
+                (TileRules.IsBlockedForEnemy(_blackBoard.TargetPlayer.CurTile) && _blackBoard.TargetPlayer.CurTile.Player == null))
                 return Result.Failure;
 
             Stack<Tile> path = _dungeon.FindPath(_enemy.CurTile, _blackBoard.TargetPlayer.CurTile);

--- a/Assets/Scripts/Unit/Enemy/Enemy.cs
+++ b/Assets/Scripts/Unit/Enemy/Enemy.cs
@@ -53,14 +53,8 @@ namespace Unit.Enemy
             BlackBoard.IsReadyToMove = false;
             
             Tile nextMoveTile = Dungeon.GetTile(nextMoveCoord.X, nextMoveCoord.Y);
-            // 갈 수 없으면 (플레이어가 있는지는 확인 X)
-            if (nextMoveTile.Status != StatusFlag.Empty)
-            {
-                //제자리 점프
-                Transform.DOMoveY(Transform.position.y + 0.5f, MOVE_TIME / 2).SetLoops(2, LoopType.Yoyo);
-            }
             // 플레이어가 있는 위치인 경우
-            else if (nextMoveTile.Coord == UnitManager.Knight.Position)
+            if (nextMoveTile.Player != null)
             {
                 // 1데미지
                 nextMoveTile.Player.TakeDamage(1);
@@ -70,19 +64,23 @@ namespace Unit.Enemy
                     (nextMoveTile.Coord.Y + Transform.position.y) / 2,
                     Transform.position.z), MOVE_TIME / 2).SetLoops(2, LoopType.Yoyo);
             }
+            // 갈 수 없으면 (플레이어가 있는지는 확인 X)
+            else if (!TileRules.CanEnemyMoveTo(nextMoveTile))
+            {
+                //제자리 점프
+                Transform.DOMoveY(Transform.position.y + 0.5f, MOVE_TIME / 2).SetLoops(2, LoopType.Yoyo);
+            }
             // 갈 수 있는 경우
             else
             {
                 // 실제 타일 이동 X
                 Tile tile = Dungeon.GetTile(Position.X, Position.Y);
-                tile.Status = StatusFlag.Empty;
                 tile.Unit = null;
                 Dungeon.SetTile(Position.X, Position.Y, tile);
                 
                 Position = nextMoveTile.Coord;
                 
                 tile = Dungeon.GetTile(Position.X, Position.Y);
-                tile.Status = StatusFlag.Unit;
                 tile.Unit = this;
                 Dungeon.SetTile(Position.X, Position.Y, tile);
             
@@ -130,7 +128,6 @@ namespace Unit.Enemy
             //현재 좌표 기반으로 타일 정보 초기화
             Tile tile = Dungeon.GetTile(Position.X, Position.Y); // 현재 적이 위치한 타일 가져오기
 
-            tile.Status = StatusFlag.Empty; // 타일 상태를 빈 상태로 초기화
             tile.Unit = null;               // 유닛 정보 제거
 
             Dungeon.SetTile(Position.X, Position.Y, tile); // 초기화된 타일 정보 반영

--- a/Assets/Scripts/Utility/PathFind.cs
+++ b/Assets/Scripts/Utility/PathFind.cs
@@ -37,7 +37,7 @@ namespace Utility
             bool pathSuccess = false;
             Stack<Tile> path= new Stack<Tile>();
 
-            if(end.Status == StatusFlag.Empty)
+            if (!TileRules.IsBlockedForEnemy(end) || end.Player != null)
             {
                 List<Tile> openSet = new List<Tile>();
                 Dictionary<Tile,PathFindCost> tileCosts = new Dictionary<Tile,PathFindCost>();
@@ -84,7 +84,7 @@ namespace Utility
                         // 1. 타일이 존재하지 않거나, 타일위에 다른 대상이 있어 지나갈수 없는 경우 갈 수 없음
                         // 2. 이미 한번 지난 타일은 갈 수 없음
                         // 3. 한번 거리를 측정한 적이 있는데 해당 측정한 경우가 더 짧은 경우
-                        if (neighbor.Status != StatusFlag.Empty) continue;
+                        if (neighbor != end && TileRules.IsBlockedForEnemy(neighbor)) continue;
                         if (closedSet.Contains(neighbor)) continue;
                         if (openSet.Contains(neighbor) && tileCosts[currentTile].GCost + GetDistance(currentTile, neighbor) >= tileCosts[neighbor].GCost) continue;
 
@@ -139,7 +139,7 @@ namespace Utility
                 {
                     Tile nextTile = dungeon.GetTile(curTile.Coord.X + (int)Dir[i].x, curTile.Coord.Y + (int)Dir[i].y);
                     if (tiles.Contains(nextTile)) continue;
-                    if (nextTile.Status != StatusFlag.Empty) continue;
+                    if (TileRules.IsBlockedForEnemy(nextTile) && nextTile.Player == null) continue;
                     if (GetDistance(currentTile,nextTile) > distance) continue;
                     
                     tiles.Add(nextTile);


### PR DESCRIPTION
### Motivation
- Centralize tile occupancy and spawn rules so movement, pathfinding and spawning logic no longer directly rely on `StatusFlag.Empty/Unit` checks.
- Support authored room layouts and deterministic unit placement by adding a preset-driven dungeon generation pipeline.

### Description
- Add `Assets/Scripts/Map/TileRules.cs` with helper predicates (`HasPlayer`, `HasUnit`, `IsBlocked`, `IsBlockedForEnemy`, `CanEnemyMoveTo`, `IsBlockedForPlayer`, `IsSpawnable`, `TryGetEnemy`) to encapsulate occupancy and spawn rules.
- Replace ad-hoc `StatusFlag` checks with `TileRules` across movement and combat code (`PlayerController`, `Unit/Enemy/Enemy.cs`, `Unit/Enemy/BT/MoveRandomlyAction.cs`, `Unit/Enemy/BT/MoveToTargetAction.cs`) and pathfinding (`Utility/PathFind.cs`) so enemies and players behave correctly on shared tiles.
- Add and update dungeon APIs in `Assets/Scripts/Map/Dungeon.cs`: `ClearTiles`, `TryGetTile`, `HasTile`, `SetOrRegisterTile`, and make `GetRandomEmptyTileFromRooms` use `TileRules` for spawnability checks.
- Introduce a preset system with `Assets/Scripts/Map/Generation/RoomPreset.cs` and `Assets/Scripts/Map/Generation/DungeonPresetGenerator.cs` to place rooms, carve corridors, and produce unit spawn lists, and integrate it into `Assets/Scripts/Workflows/DungeonSceneWorkflow.cs` via `usePresetGenerator`, `presetConfig`, and `TryGetSpawnType` mapping.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69606ccd322083208efee1fc40fe51dd)